### PR TITLE
Added possibility to filter by frontpage

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -15,6 +15,7 @@ use Flarum\Api\Controller\ListDiscussionsController;
 use Flarum\Api\Serializer\DiscussionSerializer;
 use Flarum\Discussion\Discussion;
 use Flarum\Discussion\Event\Saving;
+use Flarum\Discussion\Filter\DiscussionFilterer;
 use Flarum\Discussion\Search\DiscussionSearcher;
 use Flarum\Extend;
 use FoF\FrontPage\Gambits\FrontGambit;
@@ -33,6 +34,9 @@ return [
 
     (new Extend\SimpleFlarumSearch(DiscussionSearcher::class))
         ->addGambit(FrontGambit::class),
+
+    (new Extend\Filter(DiscussionFilterer::class))
+        ->addFilter(FrontGambit::class),
 
     (new Extend\Model(Discussion::class))
         ->dateAttribute('frontdate'),

--- a/src/Gambits/FrontGambit.php
+++ b/src/Gambits/FrontGambit.php
@@ -11,13 +11,16 @@
 
 namespace FoF\FrontPage\Gambits;
 
+use Flarum\Filter\FilterInterface;
+use Flarum\Filter\FilterState;
 use Flarum\Query\AbstractQueryState;
 use Flarum\Search\AbstractRegexGambit;
+use Illuminate\Database\Query\Builder;
 
-class FrontGambit extends AbstractRegexGambit
+class FrontGambit extends AbstractRegexGambit implements FilterInterface
 {
     /**
-     * @return [type]
+     * @return string
      */
     public function getGambitPattern()
     {
@@ -25,14 +28,39 @@ class FrontGambit extends AbstractRegexGambit
     }
 
     /**
+     * @return string
+     */
+    public function getFilterKey(): string
+    {
+        return 'frontpage';
+    }
+
+    /**
      * @param AbstractQueryState $search
      * @param array              $matches
      * @param mixed              $negate
      *
-     * @return [type]
+     * @return void
      */
     public function conditions(AbstractQueryState $search, array $matches, $negate)
     {
-        $search->getQuery()->where('frontpage', !$negate);
+        $this->constrain($search->getQuery(), $negate);
+    }
+
+    /**
+     * @param FilterState $search
+     * @param string      $filterValue
+     * @param mixed       $negate
+     *
+     * @return void
+     */
+    public function filter(FilterState $filterState, string $filterValue, bool $negate)
+    {
+        $this->constrain($filterState->getQuery(), $negate);
+    }
+
+    protected function constrain(Builder $query, bool $negate)
+    {
+        $query->where('frontpage', !$negate);
     }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
The `FrontGambit` now also implements `FilterInterface` to enable API calls that use the filter parameter, so that it's not need to use the `q` parameter and in that way prevent to perform a search query.

**Reviewers should focus on:**
If the filter parameter works fine and doesn't break the gambit that is still in use.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
